### PR TITLE
openapi_json: use native json on OTP 27+

### DIFF
--- a/src/openapi_json.erl
+++ b/src/openapi_json.erl
@@ -3,6 +3,31 @@
 -export([encode/1]).
 -export([decode/1, decode_with_atoms/1]).
 
+-if(?OTP_RELEASE >= 27).
+
+decode(Bin) ->
+  try
+    json:decode(Bin)
+  catch
+    _:_:_ -> {error, broken_json}
+  end.
+
+json_push_atom(Key, Value, Acc) ->
+  [{binary_to_atom(Key), Value} | Acc].
+
+decode_with_atoms(Bin) ->
+  {Object, ok, <<>>} = json:decode(Bin, ok, #{object_push => fun json_push_atom/3}),
+  Object.
+
+encode(Source) ->
+  try
+    iolist_to_binary(json:encode(Source))
+  catch
+    _:_:_ -> iolist_to_binary(json:encode(#{error => error_in_json_encoder, input => iolist_to_binary(io_lib:format("~p",[Source]))}))
+  end.
+
+-else. %% ?OTP_RELEASE < 27
+
 decode(Bin) ->
   try jsx:decode(Bin,[return_maps])
   catch
@@ -12,12 +37,10 @@ decode(Bin) ->
 decode_with_atoms(Bin) ->
   jsx:decode(Bin,[return_maps,{labels,atom}]).
 
-
-
-
 encode(Source) ->
   try jsx:encode(Source)
   catch
     _:_:_ -> jsx:encode(#{error => error_in_json_encoder, input => iolist_to_binary(io_lib:format("~p",[Source]))})
   end.
 
+-endif. %% ?OTP_RELEASE

--- a/test/openapi_handler_SUITE.erl
+++ b/test/openapi_handler_SUITE.erl
@@ -179,7 +179,7 @@ non_exist_key(_) ->
   #{<<"extra_keys">> := [<<"non_exist">>],
     <<"input1">> := #{<<"firstName">> := <<"Anna">>,<<"non_exist">> := <<"some">>},
     <<"name">> := <<"request_body">>,
-    <<"while">> := <<"parsing_parameters">>} = jsx:decode(Res),
+    <<"while">> := <<"parsing_parameters">>} = openapi_json:decode(Res),
   ok.
 
 non_exist_key_drop(_) ->
@@ -291,7 +291,7 @@ json_array_error(_) ->
 json_array_ok(_) ->
   Array = [1,2,3],
   Res = openapi_client:call(test_schema_api, jsonArray, #{json_body => Array}),
-  #{<<"json_res">> := <<"1">>} = jsx:decode(Res),
+  #{<<"json_res">> := <<"1">>} = openapi_json:decode(Res),
   ok.
 
 putFile(#{req := Req, '$cowboy_req' := CowboyReq}) ->


### PR DESCRIPTION
OTP27 has native JSON support.  

This PR makes openapi_json use it instead of jsx.