### PR TITLE
Autoconvert atom to binary; fix crash with type: null

### DIFF
--- a/src/openapi_schema.erl
+++ b/src/openapi_schema.erl
@@ -378,9 +378,10 @@ encode3(#{enum := Choices, type := <<"string">>}, #{auto_convert := Convert}, In
     false -> {error, #{unknown_enum_option => Input, path => Path, available => Choices}}
   end;
 
-encode3(#{type := <<"string">>} = Spec, _, Input, Path) ->
+encode3(#{type := <<"string">>} = Spec, #{auto_convert := Convert}, Input, Path) ->
   {Input1, InputForValidation} = case Input of
     _ when is_binary(Input) -> {Input, Input};
+    _ when is_atom(Input) andalso Convert -> {atom_to_binary(Input), atom_to_binary(Input)};
     _ when is_atom(Input) -> {Input, atom_to_binary(Input)};
     _ -> {{error, #{error => not_string, path => Path, input => Input}}, undefined}
   end,

--- a/src/openapi_schema.erl
+++ b/src/openapi_schema.erl
@@ -415,6 +415,13 @@ encode3(#{type := <<"boolean">>}, #{auto_convert := Convert}, Input, Path) ->
     _ -> {error, #{error => not_boolean, path => Path}}
   end;
 
+encode3(#{type := null}, #{}, Input, Path) ->
+  case Input of
+    null -> undefined;
+    undefined -> undefined;
+    _ -> {error, #{error => not_null, path => Path}}
+  end;
+
 encode3(#{type := [_| _] = Types} = Schema, Opts, Input, Path) ->
   encode3_multi_types(Types, Schema, Opts, Input, Path).
 

--- a/test/openapi_schema_SUITE.erl
+++ b/test/openapi_schema_SUITE.erl
@@ -90,11 +90,14 @@ null_in_array(_) ->
 nullable_by_oneof(_) ->
   % OAS 3.1 supports all JSON types https://spec.openapis.org/oas/v3.1.0.html#data-types
   % Also 'nullable' is invalid in OAS 3.1, and oneOf with {type: null} is suggested instead
-  Props = #{nk => #{oneOf => [#{type => string}, #{type => null}]}, k2 => #{type => <<"integer">>, default => 42}},
+  Props = #{nk => #{oneOf => [#{type => <<"string">>}, #{type => null}]}, k2 => #{type => <<"integer">>, default => 42}},
   Schema = #{type => <<"object">>, properties => Props},
   % There was a bug where null value caused extra_keys error
   Expect1 = #{nk => undefined},
   Expect1 = openapi_schema:process(#{nk => null}, #{schema => Schema, extra_obj_key => error}),
+  Expect1s = #{nk => <<"hello">>},
+  Expect1s = openapi_schema:process(#{nk => <<"hello">>}, #{schema => Schema, extra_obj_key => error}),
+  {error, _} = openapi_schema:process(#{nk => 42}, #{schema => Schema, extra_obj_key => error}),
   % Normalize the given object with a nulled key as much as possible
   Expect2 = #{nk => undefined, k2 => 42},
   Expect2 = openapi_schema:process(#{nk => null}, #{schema => Schema, extra_obj_key => error, apply_defaults => true}),

--- a/test/openapi_schema_SUITE.erl
+++ b/test/openapi_schema_SUITE.erl
@@ -142,9 +142,9 @@ regexp_pattern(_) ->
 
   {error, #{error := nomatch_pattern}} = openapi_schema:process(<<"123">>, #{schema => #{type => <<"string">>, pattern => <<"^[a-z]+$">>}}),
   % {error, #{error := not_string}} = openapi_schema:process(abc, #{schema => #{type => <<"string">>, pattern => <<"^[a-z]+$">>}}),
-  abc = openapi_schema:process(abc, #{schema => #{type => <<"string">>, pattern => <<"^[a-z]+$">>}}),
+  <<"abc">> = openapi_schema:process(abc, #{schema => #{type => <<"string">>, pattern => <<"^[a-z]+$">>}}),
   <<"abc">> =  openapi_schema:process(<<"abc">>, #{schema => #{type => <<"string">>, pattern => <<"^[a-z]+$">>}}),
-  abc =  openapi_schema:process(abc, #{schema => #{type => <<"string">>}}),
+  <<"abc">> =  openapi_schema:process(abc, #{schema => #{type => <<"string">>}}),
 
   ok.
 


### PR DESCRIPTION
Here are two changes:
* atoms are now auto-converted to binaries for `type: string`
* crash with `oneOf` and `type: null` is fixed