### PR TITLE
openapi_schema: fix null type: type name must be string

### DIFF
--- a/src/openapi_schema.erl
+++ b/src/openapi_schema.erl
@@ -220,7 +220,7 @@ encode3(#{type := <<"object">>, properties := Properties} = Schema, #{query := Q
         #{nullable := true} ->
           true;
         #{oneOf := OneOf} ->
-          lists:any(fun(#{type := null}) -> true; (_) -> false end, OneOf);
+          lists:any(fun(#{type := <<"null">>}) -> true; (_) -> false end, OneOf);
         #{} ->
           false
       end,
@@ -415,7 +415,7 @@ encode3(#{type := <<"boolean">>}, #{auto_convert := Convert}, Input, Path) ->
     _ -> {error, #{error => not_boolean, path => Path}}
   end;
 
-encode3(#{type := null}, #{}, Input, Path) ->
+encode3(#{type := <<"null">>}, #{}, Input, Path) ->
   case Input of
     null -> undefined;
     undefined -> undefined;

--- a/test/openapi_schema_SUITE.erl
+++ b/test/openapi_schema_SUITE.erl
@@ -89,8 +89,8 @@ null_in_array(_) ->
 
 nullable_by_oneof(_) ->
   % OAS 3.1 supports all JSON types https://spec.openapis.org/oas/v3.1.0.html#data-types
-  % Also 'nullable' is invalid in OAS 3.1, and oneOf with {type: null} is suggested instead
-  Props = #{nk => #{oneOf => [#{type => <<"string">>}, #{type => null}]}, k2 => #{type => <<"integer">>, default => 42}},
+  % Also 'nullable' is invalid in OAS 3.1, and oneOf with {type: 'null'} is suggested instead
+  Props = #{nk => #{oneOf => [#{type => <<"string">>}, #{type => <<"null">>}]}, k2 => #{type => <<"integer">>, default => 42}},
   Schema = #{type => <<"object">>, properties => Props},
   % There was a bug where null value caused extra_keys error
   Expect1 = #{nk => undefined},


### PR DESCRIPTION
In previous PRs I implemented support for null type declared as:
```YAML
type: null
```  
I was wrong because type must be a string, so valid declaration is:
```YAML
type: 'null'
```

For Erlang syntax this means changing `type := null` to `type := <<"null">>`, and this PR does it.