### PR TITLE
Discriminator improvements

### DIFF
--- a/src/openapi_schema.erl
+++ b/src/openapi_schema.erl
@@ -210,7 +210,7 @@ encode3(#{discriminator := #{propertyName := DKey, mapping := DMap}} = Schema, O
   ADvalue1 = DefaultFun(Input),
   ADvalue2 = case ADvalue1 of
     undefined ->
-      Try = encode3(hd(Types), Opts#{apply_defaults => true}, Input, Path),
+      Try = encode3(hd(Types), Opts#{apply_defaults => true, required_obj_keys => drop}, Input, Path),
       DefaultFun(Try);
     _ ->
       ADvalue1

--- a/test/fake_petstore.erl
+++ b/test/fake_petstore.erl
@@ -28,7 +28,7 @@ updateUser(#{username := <<"Mary">>, json_body := Body}) ->
 
 % A parameter in a query string
 findPetsByStatus(#{status := [pending,sold]}) -> 
-  {json, 200, [#{name => <<"Dingo">>, photoUrls => 1}]}.
+  {json, 200, [#{petType => dog, name => <<"Dingo">>, photoUrls => 1}]}.
 
 % Object in a JSON body
 placeOrder(#{json_body := #{petId := 7214, status := placed} = Order}) ->

--- a/test/openapi_schema_SUITE.erl
+++ b/test/openapi_schema_SUITE.erl
@@ -16,6 +16,7 @@ groups() ->
       null_in_array,
       nullable_by_oneof,
       discriminator,
+      recursive_discriminator,
       non_object_validate,
       regexp_pattern,
       external_validators,
@@ -153,6 +154,61 @@ discriminator(_) ->
 
   ok.
 
+% See example without oneOf at https://spec.openapis.org/oas/v3.1.0.html#discriminator-object
+% The same happens in redocly-petstore.yaml:
+%   Pet:
+%     petType: {type: string}
+%     discriminator: {propertyName: petType, mapping: {...}}
+%   Cat:
+%     allOf: [Pet, {type: object, ...}]
+%
+% > To avoid redundancy, the discriminator MAY be added to a parent schema definition,
+%   and all schemas comprising the parent schema in an allOf construct may be used as an alternate schema.
+% So, discriminator is handled at top-level component, and later must be ignored
+%
+% Also the same example shows how oneOf can be omitted.
+% openapi_schema has a stricter behaviour, not supporting implicit mapping
+recursive_discriminator(_) ->
+  % risk of unterminated recursion, thus timetrap
+  ct:timetrap(500),
+
+  FooProp = #{k1 => #{type => <<"integer">>, default => 101}},
+  BarProp = #{k2 => #{type => <<"integer">>, default => 22}},
+  FooOwn = #{type => <<"object">>, properties => FooProp},
+  BarOwn = #{type => <<"object">>, properties => BarProp},
+  FooType = #{allOf => [#{'$ref' => <<"#/components/schemas/discr_t">>}, FooOwn]},
+  BarType = #{allOf => [#{'$ref' => <<"#/components/schemas/discr_t">>}, BarOwn]},
+  Mapping = #{foo => <<"#/components/schemas/foo_t">>, bar => <<"#/components/schemas/bar_t">>},
+
+  DSchemaForDis = fun(DisSchema) ->
+    BaseProp = #{k3 => #{type => <<"integer">>}, dis => DisSchema},
+    DType = #{type => <<"object">>, properties => BaseProp, discriminator => #{propertyName => <<"dis">>, mapping => Mapping}},
+    #{components => #{schemas => #{discr_t => DType, foo_t => FooType, bar_t => BarType}}}
+  end,
+
+  % Easy case: discriminator is defined as oneOf(const) and passed explicitly
+  DSchema1 = DSchemaForDis(#{oneOf => [#{const => <<"foo">>}, #{const => <<"bar">>}]}),
+  #{dis := foo, k1 := 101} = openapi_schema:process(#{dis => <<"foo">>}, #{type => discr_t, whole_schema => DSchema1, apply_defaults => true}),
+  #{dis := bar, k2 := 22} = openapi_schema:process(#{dis => <<"bar">>}, #{type => discr_t, whole_schema => DSchema1, apply_defaults => true}),
+
+  % Harder case: discriminator is just type: string
+  DSchema2 = DSchemaForDis(#{type => <<"string">>}),
+  #{dis := foo, k1 := 101} = openapi_schema:process(#{dis => <<"foo">>}, #{type => discr_t, whole_schema => DSchema2, apply_defaults => true}),
+  #{dis := bar, k2 := 22} = openapi_schema:process(#{dis => <<"bar">>}, #{type => discr_t, whole_schema => DSchema2, apply_defaults => true}),
+
+  % Hard case: discriminator has default value
+  DSchema3a = DSchemaForDis(#{type => <<"string">>, default => <<"foo">>}),
+  #{dis := foo, k1 := 101} = openapi_schema:process(#{}, #{type => discr_t, whole_schema => DSchema3a, apply_defaults => true}),
+  DSchema3b = DSchemaForDis(#{type => <<"string">>, default => <<"bar">>}),
+  #{dis := bar, k2 := 22} = openapi_schema:process(#{}, #{type => discr_t, whole_schema => DSchema3b, apply_defaults => true}),
+
+  [] = maps:keys(openapi_schema:process(#{}, #{type => discr_t, whole_schema => DSchema3b})),
+  [k2, k3] = maps:keys(openapi_schema:process(#{k2 => 11, k3 => 435}, #{type => discr_t, whole_schema => DSchema3b})),
+  % k1 from foo_t is handled like dis=bar
+  [] = maps:keys(openapi_schema:process(#{k1 => 43}, #{type => discr_t, whole_schema => DSchema3b})),
+  {error, #{extra_keys := [k1]}} = openapi_schema:process(#{k1 => 43}, #{type => discr_t, whole_schema => DSchema3b, extra_obj_key => error}),
+
+  ok.
 
 non_object_validate(_) ->
   {error, #{error := not_object}} = openapi_schema:process([<<"123">>], #{schema => #{type => <<"object">>}}),

--- a/test/openapi_schema_SUITE.erl
+++ b/test/openapi_schema_SUITE.erl
@@ -16,6 +16,7 @@ groups() ->
       null_in_array,
       nullable_by_oneof,
       discriminator,
+      discriminator_default_missing_fields,
       recursive_discriminator,
       non_object_validate,
       regexp_pattern,
@@ -209,6 +210,26 @@ recursive_discriminator(_) ->
   {error, #{extra_keys := [k1]}} = openapi_schema:process(#{k1 => 43}, #{type => discr_t, whole_schema => DSchema3b, extra_obj_key => error}),
 
   ok.
+
+discriminator_default_missing_fields(_) ->
+  FooProp = #{dis => #{type => <<"string">>}, k1 => #{type => <<"integer">>}, k3 => #{type => <<"integer">>}},
+  BarProp = #{dis => #{type => <<"string">>}, k2 => #{type => <<"integer">>}, k3 => #{type => <<"integer">>}},
+  FooOwn = #{type => <<"object">>, properties => FooProp, required => [<<"k3">>]},
+  BarOwn = #{type => <<"object">>, properties => BarProp, required => [<<"k2">>, <<"k3">>]},
+  FooType = #{allOf => [#{'$ref' => <<"#/components/schemas/discr_t">>}, FooOwn]},
+  BarType = #{allOf => [#{'$ref' => <<"#/components/schemas/discr_t">>}, BarOwn]},
+  Mapping = #{foo => <<"#/components/schemas/foo_t">>, bar => <<"#/components/schemas/bar_t">>},
+  DSchemaForDis = fun(DisSchema) ->
+    BaseProp = #{dis => DisSchema},
+    DType = #{type => <<"object">>, properties => BaseProp, discriminator => #{propertyName => <<"dis">>, mapping => Mapping}},
+    #{components => #{schemas => #{discr_t => DType, foo_t => FooType, bar_t => BarType}}}
+  end,
+  DSchema_foo = DSchemaForDis(#{type => <<"string">>, default => <<"foo">>}),
+  {error, #{missing_required := [<<"k3">>]}} = openapi_schema:process(#{}, #{type => discr_t, whole_schema => DSchema_foo, required_obj_keys => error}),
+  DSchema_bar = DSchemaForDis(#{type => <<"string">>, default => <<"bar">>}),
+  {error, #{missing_required := [<<"k2">>]}} = openapi_schema:process(#{k3 => 1}, #{type => discr_t, whole_schema => DSchema_bar, required_obj_keys => error}),
+  ok.
+
 
 non_object_validate(_) ->
   {error, #{error := not_object}} = openapi_schema:process([<<"123">>], #{schema => #{type => <<"object">>}}),

--- a/test/openapi_schema_SUITE.erl
+++ b/test/openapi_schema_SUITE.erl
@@ -30,6 +30,7 @@ groups() ->
       check_explain,
       check_explain_on_error,
       one_of_integer_const,
+      one_of_const_default,
       filter_read_only_props
     ]},
     {introspection, [], [
@@ -299,6 +300,15 @@ one_of_integer_const(_) ->
     name := <<"one_of_integer_const">>,
     inputs := [#{apts := 1}, #{apts := 3}, #{apts := video}]
   } = openapi_schema:process(Json, #{type => stream_config, whole_schema => Schema, apply_defaults => true, explain => [required]}),
+  ok.
+
+one_of_const_default(_) ->
+  % When type is oneof(const), default should be returned as atom
+  FooProp = #{k1 => #{oneOf => [#{const => <<"hello">>}, #{const => <<"world">>}], default => <<"world">>}},
+  FooType = #{type => <<"object">>, properties => FooProp},
+  #{k1 := world} = openapi_schema:process(
+        #{},
+        #{schema => FooType, apply_defaults => true}),
   ok.
 
 filter_read_only_props(_) ->


### PR DESCRIPTION
Here I add support for discriminator similar to one in example schemas:
```
components:
  schemas:
    Pet:
      type: object
      required:
      - petType
      properties:
        petType:
          type: string
      discriminator:
        propertyName: petType
        mapping:
          dog: Dog
          cat: Cat
    Cat:
      allOf:
      - $ref: '#/components/schemas/Pet'
      - type: object
        # all other properties specific to a `Cat`
    Dog:
      allOf:
      - $ref: '#/components/schemas/Pet'
      - type: object
        # all other properties specific to a `Dog`
```
Notice no `oneOf` in `Pet` schema (it is derived from mapping)  

Also as a pre-requisite I've fixed `oneOf(const)` + `default` behaviour, now default is returned as atom.