### PR TITLE
fix a crash when ordinary field behind discriminator has wrong format

### DIFF
--- a/src/openapi_schema.erl
+++ b/src/openapi_schema.erl
@@ -208,10 +208,11 @@ encode3(#{discriminator := #{propertyName := DKey, mapping := DMap}} = Schema, O
       #{} -> undefined
     end
   end,
-  ADvalue1 = DefaultFun(Input),
+  DiscrInput = maps:with([DKey, ADKey], Input),
+  ADvalue1 = DefaultFun(DiscrInput),
   ADvalue2 = case ADvalue1 of
     undefined ->
-      Try = encode3(hd(Types), Opts#{apply_defaults => true, required_obj_keys => drop}, Input, Path),
+      Try = encode3(hd(Types), Opts#{apply_defaults => true, required_obj_keys => drop}, DiscrInput, Path),
       DefaultFun(Try);
     _ ->
       ADvalue1


### PR DESCRIPTION
Case:
 * input has no explicit discriminator, so code looks up default value
 * other input key has wrong type or format
 * crash with case clause error

Solution: when resolving default discriminator value, only discriminator field is passed for filling defaults, preventing interference from other keys on this stage.