### PR TITLE
openapi_schema: boolean values should not be valid strings

### DIFF
--- a/src/openapi_schema.erl
+++ b/src/openapi_schema.erl
@@ -466,6 +466,7 @@ encode3(#{enum := Choices, type := <<"string">>}, #{auto_convert := Convert}, In
 encode3(#{type := <<"string">>} = Spec, #{auto_convert := Convert} = Options, Input, Path) ->
   {Input1, InputForValidation} = case Input of
     _ when is_binary(Input) -> {Input, Input};
+    _ when is_boolean(Input) -> {{error, #{error => not_string, path => Path, input => Input}}, undefined};
     _ when is_atom(Input) andalso Convert -> {atom_to_binary(Input), atom_to_binary(Input)};
     _ when is_atom(Input) -> {Input, atom_to_binary(Input)};
     _ -> {{error, #{error => not_string, path => Path, input => Input}}, undefined}

--- a/test/openapi_schema_SUITE.erl
+++ b/test/openapi_schema_SUITE.erl
@@ -15,6 +15,7 @@ groups() ->
       extra_keys_drop,
       null_in_array,
       nullable_by_oneof,
+      boolean_vs_string,
       discriminator,
       discriminator_default_missing_fields,
       discriminator_default_wrong_format,
@@ -115,6 +116,12 @@ nullable_by_oneof(_) ->
   % Normalize the given object with a nulled key as much as possible
   Expect2 = #{nk => undefined, k2 => 42},
   Expect2 = openapi_schema:process(#{nk => null}, #{schema => Schema, extra_obj_key => error, apply_defaults => true}),
+  ok.
+
+boolean_vs_string(_) ->
+  % Even when auto_convert is enabled (default behaviour) consider boolean values not valid strings
+  {error, _} = openapi_schema:process(true, #{schema => #{type => <<"string">>}}),
+  {error, _} = openapi_schema:process(false, #{schema => #{type => <<"string">>}}),
   ok.
 
 discriminator(_) ->


### PR DESCRIPTION
Boolean values (`true`, `false`) are not valid strings any more,  even with `auto_convert`.  
Rationale:
* When processing input, `const` values are expected to be atoms, thus `auto_convert` is needed
* booleans (got from JSON) should fail validation as strings