### PR TITLE
Fix write only behaviour

### DIFF
--- a/test/example-openapi.json
+++ b/test/example-openapi.json
@@ -1,0 +1,41 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "contact": { "email": "hello@exampl.com", "name": "Test", "url": "https://example.com/" },
+    "description": "dummy desc",
+    "title": "Test API",
+    "version": "0.1.0"
+  },
+  "components": {
+    "schemas": {
+      "external_validators_simple": {
+        "type": "string",
+        "format": "no_space"
+      },
+      "external_validators_array": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "no_space"
+          }
+        }
+      },
+      "external_validators_object": {
+        "type": "object",
+        "properties": {
+          "in_object": {
+            "type": "object",
+            "properties": {
+              "prop1": {
+                "type": "string",
+                "format": "no_space"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/openapi_handler_SUITE.erl
+++ b/test/openapi_handler_SUITE.erl
@@ -438,18 +438,12 @@ required_keys_filter(_) ->
 
 
 select_not_filters_required_keys(_) ->
+  % p3 is 'writeOnly', so it should be dropped in results
   #{elements := [Elem1,Elem1]} = openapi_client:call(test_schema_api, selectCollectionFields,
       #{json_body => #{p1 => 1, p2 => 2, p3 => 3, p4 => 4, p5 => 5}}),
-  #{p1 := 1, p2 := 2, p3 := 3, p4 := 4, p5 :=5} = Elem1,
+  #{p1 := 1, p2 := 2, p4 := 4, p5 :=5} = Elem1,
 
-  % p1, p2 are 'readOnly' required keys
-  #{elements := [Elem2,Elem2]} = openapi_client:call(test_schema_api, selectCollectionFields,
-      #{json_body => #{p1 => 1, p2 => 2, p3 => 3, p4 => 4, p5 => 5}, select => <<"p3">>}),
-  #{p1 := 1, p2 := 2, p3 := 3} = Elem2,
-  undefined = maps:get(p4, Elem2, undefined),
-  undefined = maps:get(p5, Elem2, undefined),
-
-  % p3 is 'writeOnly' required key
+  % p1, p2 are required keys, so they are returned despite not explicitly requested
   #{elements := [Elem3,Elem3]} = openapi_client:call(test_schema_api, selectCollectionFields,
       #{json_body => #{p1 => 1, p2 => 2, p3 => 3, p4 => 4, p5 => 5}, select => <<"p4">>}),
   #{p1 := 1, p2 := 2, p4 := 4} = Elem3,


### PR DESCRIPTION
JSON Schema says:
> writeOnly indicates that a value may be set, but will remain hidden. In could be used to indicate you can set a value with a PUT request, but it would not be included when retrieving that record with a GET request.

Here I implement writeOnly property filtering on read access, to complement [readOnly filtering on write](https://github.com/flussonic/openapi_handler/commit/03f73145684bbb605a4a89985b39b8b164a6f2ea)

This changes 'read' access behaviour, so a new access_type is introduce to disable any read/write filtering -- `access_type => raw`


Additionally, I add a fixture I forgot to add in previous PR https://github.com/flussonic/openapi_handler/pull/13