### PR TITLE
openapi_schema: fix error when passed discriminator has wrong type

### DIFF
--- a/src/openapi_schema.erl
+++ b/src/openapi_schema.erl
@@ -207,7 +207,8 @@ encode3(#{discriminator := #{propertyName := DKey, mapping := DMap}} = Schema, O
         try binary_to_existing_atom(DValue) catch error:badarg -> DValue end;
       #{ADKey := DValue} when is_binary(DValue) ->
         try binary_to_existing_atom(DValue) catch error:badarg -> DValue end;
-      #{} -> undefined
+      #{} -> undefined;
+      {error, _} -> Input_
     end
   end,
   DiscrInput = maps:with([DKey, ADKey], Input),
@@ -225,6 +226,9 @@ encode3(#{discriminator := #{propertyName := DKey, mapping := DMap}} = Schema, O
       encode3(maps:without([discriminator], Schema), Opts, Input, Path);
     {undefined, _} ->
       {error, #{error => discriminator_missing, path => Path, propertyName => DKey}};
+    {{error, _}, _} ->
+      % this error comes from processing discriminator with first possible type, and may contain useful type error (e.g. not_string)
+      ADvalue2;
     {_, undefined} ->
       {error, #{error => discriminator_unmapped, path => Path, propertyName => DKey, value => ADvalue2}};
     {_, _} ->

--- a/test/openapi_schema_SUITE.erl
+++ b/test/openapi_schema_SUITE.erl
@@ -165,6 +165,8 @@ discriminator(_) ->
   Foo5 = openapi_schema:process(#{k1 => 12, k2 => 34, k4 => 56}, #{type => discr_t, whole_schema => DSchema1}),
   [k1, k4] = lists:sort(maps:keys(Foo5)), % apply default
 
+  {error, #{error := not_string}} = openapi_schema:process(#{dis => 42}, #{type => discr_t, query => true, whole_schema => DSchema}),
+
   ok.
 
 % See example without oneOf at https://spec.openapis.org/oas/v3.1.0.html#discriminator-object
@@ -214,6 +216,8 @@ recursive_discriminator(_) ->
   #{dis := foo, k1 := 101} = openapi_schema:process(#{}, #{type => discr_t, whole_schema => DSchema3a, apply_defaults => true}),
   DSchema3b = DSchemaForDis(#{type => <<"string">>, default => <<"bar">>}),
   #{dis := bar, k2 := 22} = openapi_schema:process(#{}, #{type => discr_t, whole_schema => DSchema3b, apply_defaults => true}),
+
+  {error, #{error := not_string}} = openapi_schema:process(#{dis => 42}, #{type => discr_t, whole_schema => DSchema3b, apply_defaults => true}),
 
   [] = maps:keys(openapi_schema:process(#{}, #{type => discr_t, whole_schema => DSchema3b})),
   [k2, k3] = maps:keys(openapi_schema:process(#{k2 => 11, k3 => 435}, #{type => discr_t, whole_schema => DSchema3b})),


### PR DESCRIPTION
In some cases bad discriminator type (e.g. integer when property has `type: string`) caused a crash.  
This PR fixes this crash.