### PR TITLE
openapi_schema: extend error message in string length restriction cases

### DIFF
--- a/src/openapi_schema.erl
+++ b/src/openapi_schema.erl
@@ -488,9 +488,9 @@ encode3(#{type := <<"string">>} = Spec, #{auto_convert := Convert} = Options, In
     _ ->
       case Spec of
         #{minLength := MinLength} when size(InputForValidation) < MinLength ->
-          {error, #{error => too_short, path => Path, input => Input, min_length => MinLength}};
+          {error, #{error => too_short, path => Path, input => Input, detail => length(Input), min_length => MinLength}};
         #{maxLength := MaxLength} when size(InputForValidation) > MaxLength ->
-          {error, #{error => too_long, path => Path, input => Input, max_length => MaxLength}};
+          {error, #{error => too_long, path => Path, input => Input, detail => length(Input), max_length => MaxLength}};
         #{} ->
           Format = maps:get(format, Spec, undefined),
           Validators = maps:get(validators, Options),


### PR DESCRIPTION
Extend error message in string length restriction cases
* too_short
* too_long