### PR TITLE
openapi_schema: count UTF8 code points when checking string length constraints

### DIFF
--- a/src/openapi_schema.erl
+++ b/src/openapi_schema.erl
@@ -486,11 +486,12 @@ encode3(#{type := <<"string">>} = Spec, #{auto_convert := Convert} = Options, In
     {error, _} ->
       Input1;
     _ ->
+      Length = string:length(InputForValidation),
       case Spec of
-        #{minLength := MinLength} when size(InputForValidation) < MinLength ->
-          {error, #{error => too_short, path => Path, input => Input, detail => length(Input), min_length => MinLength}};
-        #{maxLength := MaxLength} when size(InputForValidation) > MaxLength ->
-          {error, #{error => too_long, path => Path, input => Input, detail => length(Input), max_length => MaxLength}};
+        #{minLength := MinLength} when Length < MinLength ->
+          {error, #{error => too_short, path => Path, input => Input, detail => Length, min_length => MinLength}};
+        #{maxLength := MaxLength} when Length > MaxLength ->
+          {error, #{error => too_long, path => Path, input => Input, detail => Length, max_length => MaxLength}};
         #{} ->
           Format = maps:get(format, Spec, undefined),
           Validators = maps:get(validators, Options),

--- a/test/openapi_schema_SUITE.erl
+++ b/test/openapi_schema_SUITE.erl
@@ -333,10 +333,21 @@ external_validators(_) ->
 
 
 min_max_length(_) ->
-  {error, #{error := too_short}} = 
+  {error, #{error := too_short, detail := 3}} =
     openapi_schema:process(<<"123">>, #{schema => #{type => <<"string">>, minLength => 5}}),
-  {error, #{error := too_long}} = 
+  {error, #{error := too_long, detail := 3}} =
     openapi_schema:process(<<"123">>, #{schema => #{type => <<"string">>, maxLength => 2}}),
+
+  {error, #{error := too_short, detail := 4}} =
+    openapi_schema:process(atom, #{schema => #{type => <<"string">>, minLength => 5}}),
+  {error, #{error := too_long, detail := 4}} =
+    openapi_schema:process(atom, #{schema => #{type => <<"string">>, maxLength => 2}}),
+
+  UTFString = unicode:characters_to_binary([128578,128579]), % 2 code points, but 8 bytes
+  {error, #{error := too_short, detail := 2}} =
+    openapi_schema:process(UTFString, #{schema => #{type => <<"string">>, minLength => 3}}),
+  {error, #{error := too_long, detail := 2}} =
+    openapi_schema:process(UTFString, #{schema => #{type => <<"string">>, maxLength => 1}}),
   ok.
 
 


### PR DESCRIPTION
This PR changes minLength/maxLength behaviour to conform with specifications:
  * OpenAPI inherits JSON schema semantics when checking string length.  
  * The length of a string instance is defined as the number of its characters as defined by [RFC 8259](https://json-schema.org/draft/2020-12/json-schema-validation#RFC8259) https://json-schema.org/draft/2020-12/json-schema-validation#section-6.3.1 
  * RFC8259 is about unicode (UTF-8) https://www.rfc-editor.org/rfc/rfc8259.html#section-8.1

Other references:
  * non-official docs say the same -- number of Unicode code-points https://www.learnjsonschema.com/2020-12/validation/maxlength/
  * official tests ensure the same https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/maxLength.json#L31


Also this PR fixes an error introduced by #16