### PR TITLE
openapi_schema: fix crash when validating array/map vs const

### DIFF
--- a/src/openapi_schema.erl
+++ b/src/openapi_schema.erl
@@ -462,6 +462,9 @@ encode3(#{const := Value}, #{auto_convert := Convert}, Input, Path) when is_atom
     _ -> {error, #{error => not_const2, path => Path, input => Input, value => Value}}
   end;
 
+encode3(#{const := Value}, #{}, Input, Path) ->
+  {error, #{error => not_const, path => Path, input => Input, value => Value}};
+
 encode3(#{enum := Choices, type := <<"string">>}, #{auto_convert := Convert}, Input, Path) ->
   InputValue = case Input of
     _ when is_binary(Input) -> Input;

--- a/test/openapi_schema_SUITE.erl
+++ b/test/openapi_schema_SUITE.erl
@@ -34,6 +34,7 @@ groups() ->
       check_explain,
       check_explain_on_error,
       one_of_integer_const,
+      one_of_const_wrong_type,
       one_of_const_default,
       drop_unidirectional_keys,
       filter_read_only_props
@@ -437,6 +438,12 @@ one_of_const_default(_) ->
         #{schema => FooType, apply_defaults => true}),
   ok.
 
+one_of_const_wrong_type(_) ->
+  FooProp = #{k1 => #{oneOf => [#{const => <<"hello">>}, #{const => <<"world">>}]}},
+  FooType = #{type => <<"object">>, properties => FooProp},
+  {error, #{error := not_const}} = openapi_schema:process(#{k1 => #{}}, #{schema => FooType}),
+  {error, #{error := not_const}} = openapi_schema:process(#{k1 => []}, #{schema => FooType}),
+  ok.
 
 drop_unidirectional_keys(_) ->
   Schema = #{


### PR DESCRIPTION
This PR fixes a crash on maps/array as input when schema is `const:`