### PR TITLE
define tests workflow, drop obsolete deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,76 @@
+name: Erlang CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+# bundled rebar3 binary has limited erts compatibility, but images have working one in PATH
+env:
+  REBAR: rebar3
+
+permissions:
+  contents: read
+
+jobs:
+
+  ci-otp-latest:
+    runs-on: ubuntu-latest
+    container:
+      image: erlang:latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run tests
+      run: make ci-test
+
+  ci-otp28:
+    runs-on: ubuntu-latest
+    container:
+      image: erlang:28
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run tests
+      run: make ci-test
+
+  ci-otp27:
+    runs-on: ubuntu-latest
+    container:
+      image: erlang:27
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run tests
+      run: make ci-test
+
+  ci-otp26:
+    runs-on: ubuntu-latest
+    container:
+      image: erlang:26
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run tests
+      run: make ci-test-pre27
+
+  ci-otp25:
+    runs-on: ubuntu-latest
+    container:
+      image: erlang:25
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run tests
+      run: make ci-test-pre27
+
+  ci-otp24:
+    runs-on: ubuntu-latest
+    container:
+      image: erlang:24
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run tests
+      run: make ci-test-pre27

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: all ci-test clean
+.PHONY: all ci-test ci-test-pre27 clean
+REBAR ?= ./rebar3
 
 all:
 	./rebar3 compile
 
 ci-test:
-	REBAR_CONFIG=rebar.config_ ./rebar3 as dev ct --logdir test-logs --readable true
+	REBAR_CONFIG=rebar.config_ $(REBAR) as dev ct --logdir test-logs --readable true
+ci-test-pre27:
+	REBAR_CONFIG=rebar.config.pre27_ $(REBAR) as dev ct --logdir test-logs --readable true
 
 clean:
 	rm -rf _build rebar.lock

--- a/rebar.config.pre27_
+++ b/rebar.config.pre27_
@@ -1,0 +1,14 @@
+% No deps by default to prevent conflicts
+{deps, [
+]}.
+
+{profiles, [
+  {dev, [
+    {deps, [
+      jsx,
+      {cowboy, "2.12.0"},
+      redbug
+    ]},
+    {ct_opts, [{ct_hooks, [cth_surefire]}]}
+  ]}
+]}.


### PR DESCRIPTION
* reduce dependencies: drop lhttpc, yamerl and jsx (when we have json in OTP)
* add tests workflow across different OTP releases to ensure PRs don't break things and to be aware of compatibility